### PR TITLE
Call By Value와 Call By Reference의 차이점

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+.idea/workspace.xml
+.idea/workspace.xml
+java/java.iml
+.idea/workspace.xml
+*.xml
+*.iml

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="d8161ad2-8343-4872-b499-99e347c064b2" name="Changes" comment="" />
+    <list default="true" id="d8161ad2-8343-4872-b499-99e347c064b2" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/java/java.iml" beforeDir="false" afterPath="$PROJECT_DIR$/java/java.iml" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -30,25 +33,25 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Application.Main.executor": "Run",
-    "Application.ThreadSyncTest.executor": "Run",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "/Users/jeongdowon/Documents/GitHub/tir",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "project.structure.last.edited": "Project",
-    "project.structure.proportion": "0.0",
-    "project.structure.side.proportion": "0.0",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Application.Main.executor&quot;: &quot;Run&quot;,
+    &quot;Application.ThreadSyncTest.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/jeongdowon/Documents/GitHub/ir&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager" selected="Application.ThreadSyncTest">
     <configuration name="Main" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="Main" />
@@ -95,6 +98,10 @@
       <workItem from="1719038828382" duration="74000" />
       <workItem from="1719038905872" duration="301000" />
       <workItem from="1719039673656" duration="2174000" />
+      <workItem from="1721106715219" duration="49000" />
+      <workItem from="1721106772159" duration="4000" />
+      <workItem from="1721106779360" duration="195000" />
+      <workItem from="1721265523464" duration="40000" />
     </task>
     <servers />
   </component>

--- a/java/java.iml
+++ b/java/java.iml
@@ -4,8 +4,25 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library" scope="TEST">
+      <library name="JUnit5.8.1">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.8.1/junit-jupiter-api-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.8.1/junit-jupiter-engine-5.8.1.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/java/src/getbyref_byvalue/Chicken.java
+++ b/java/src/getbyref_byvalue/Chicken.java
@@ -1,0 +1,31 @@
+package getbyref_byvalue;
+
+public class Chicken {
+    private Integer weight;
+    private Boolean boneless;
+
+    public Chicken(int weight, boolean boneless) {
+        this.weight = weight;
+        this.boneless = boneless;
+    }
+
+    public boolean cookingCompleted() {
+        return boneless;
+    }
+
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public Boolean isBoneless() {
+        return boneless;
+    }
+
+    public void setWeight(int weight) {
+        this.weight = weight;
+    }
+
+    public void setBoneless(boolean boneless) {
+        this.boneless = boneless;
+    }
+}

--- a/java/src/getbyref_byvalue/GetBy.java
+++ b/java/src/getbyref_byvalue/GetBy.java
@@ -1,0 +1,24 @@
+package getbyref_byvalue;
+
+public class GetBy {
+    public static final int CHICKEN_BONE_WIGHT = 736;
+
+    public void makeBonelessByReference(Chicken chicken) throws RuntimeException {
+        if (chicken.cookingCompleted()) {
+            throw new RuntimeException("이미 조리 완료된 치킨입니다.");
+        }
+
+        chicken.setBoneless(true);
+        chicken.setWeight(chicken.getWeight() - CHICKEN_BONE_WIGHT);
+    }
+
+    public void makeBonelessByValue(int chickenWeight, boolean boneless) {
+        chickenWeight -= CHICKEN_BONE_WIGHT;
+        boneless = true;
+    }
+
+    public void makeBonelessByWrapper(Integer chickenWeight, Boolean boneless) {
+        chickenWeight = Integer.valueOf(chickenWeight - CHICKEN_BONE_WIGHT);
+        boneless = Boolean.valueOf(true);
+    }
+}

--- a/java/src/thread_sync/SynchronizedSyncTest.java
+++ b/java/src/thread_sync/SynchronizedSyncTest.java
@@ -1,21 +1,29 @@
 package thread_sync;
 
-public class VolatileSyncTest {
-    volatile int var = 0;
+public class SynchronizedSyncTest {
+    private int var = 0;
 
-    public void test(){
+    public synchronized int getVar() {
+        return var;
+    }
+
+    public synchronized void increment() {
+        var += 1;
+    }
+
+    public void test() {
         Thread thread1 = new Thread(() -> {
             System.out.println("Thread1 starts");
-            for(int i=0; i<10000; i++){
-                var++;
+            for (int i = 0; i < 10000; i++) {
+                increment();
             }
             System.out.println("Thread1 finished");
         });
 
         Thread thread2 = new Thread(() -> {
             System.out.println("Thread2 starts");
-            for(int i=0; i<10000; i++){
-                var++;
+            for (int i = 0; i < 10000; i++) {
+                increment();
             }
             System.out.println("Thread2 finished");
         });
@@ -23,30 +31,18 @@ public class VolatileSyncTest {
         thread1.start();
         thread2.start();
 
-        try{
+        try {
             thread1.join();
             thread2.join();
-        }catch (InterruptedException e){
+        } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
 
-        System.out.println("var = " + var);
+        System.out.println("var = " + getVar());
     }
 
     public static void main(String[] args) {
-        VolatileSyncTest test = new VolatileSyncTest();
+        SynchronizedSyncTest test = new SynchronizedSyncTest();
         test.test();
-
     }
 }
-
-/*
-결과:
-
-Thread1 starts
-Thread1 finished
-10000
-Thread2 starts
-Thread2 finished
-
- */

--- a/java/src/thread_sync/ThreadSyncUsingStatic.java
+++ b/java/src/thread_sync/ThreadSyncUsingStatic.java
@@ -1,7 +1,7 @@
 package thread_sync;
 
 public class ThreadSyncUsingStatic {
-    boolean flag = true;
+    static boolean flag = true;
 
     public void test() {
         new Thread(() -> {

--- a/java/src/thread_sync/ThreadSyncUsingStatic.java
+++ b/java/src/thread_sync/ThreadSyncUsingStatic.java
@@ -7,7 +7,12 @@ public class ThreadSyncUsingStatic {
         new Thread(() -> {
             System.out.println("Thread1 starts");
             int count = 0;
-            while (flag) {
+            try {
+                Thread.sleep(600);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            while (ThreadSyncUsingStatic.flag) {
                 count++;
             }
             System.out.println("Thread1 finished");
@@ -20,8 +25,10 @@ public class ThreadSyncUsingStatic {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
-            System.out.println("Thread2 finished");
             flag = false;
+            // ThreadSyncUsingStatic.setFlag();
+            System.out.println("flag in thread = " + flag);
+            System.out.println("Thread2 finished");
         }).start();
     }
 
@@ -29,6 +36,12 @@ public class ThreadSyncUsingStatic {
         ThreadSyncUsingStatic test = new ThreadSyncUsingStatic();
         test.test();
 
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        System.out.println("ThreadSyncUsingStatic.flag = " + ThreadSyncUsingStatic.flag);
     }
 }
 

--- a/java/test/MainTest.java
+++ b/java/test/MainTest.java
@@ -1,0 +1,30 @@
+import org.junit.jupiter.api.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MainTest {
+
+    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+    @BeforeEach
+    public void setUp() {
+        System.setOut(new PrintStream(outputStreamCaptor));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        System.setOut(System.out);
+    }
+
+    @Test
+    @DisplayName("테스트가 성공됩니다.")
+    void testMain(){
+        Main.main(new String[]{});
+
+        assertEquals("Hello world!", outputStreamCaptor.toString().trim());
+    }
+
+}

--- a/java/test/getbyref_byvalue/GetByTest.java
+++ b/java/test/getbyref_byvalue/GetByTest.java
@@ -1,0 +1,58 @@
+package getbyref_byvalue;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GetByTest {
+
+    @Test
+    @DisplayName("get by reference")
+    void testGetByRef() {
+        // given
+        int chickenWeight = 1100;
+        Chicken chicken = new Chicken(chickenWeight, false);
+
+        // when
+        GetBy getBy = new GetBy();
+        getBy.makeBonelessByReference(chicken);
+
+        // then
+        Assertions.assertNotEquals(chickenWeight, chicken.getWeight());
+        Assertions.assertEquals(chickenWeight - GetBy.CHICKEN_BONE_WIGHT, chicken.getWeight());
+    }
+
+    @Test
+    @DisplayName("get by value")
+    void testGetByValue() {
+        // given
+        int chickenWeight = 1100;
+        Chicken chicken = new Chicken(chickenWeight, false);
+
+        // when
+        GetBy getBy = new GetBy();
+        getBy.makeBonelessByValue(chicken.getWeight(), chicken.isBoneless());
+
+        // then
+        Assertions.assertEquals(chickenWeight, chicken.getWeight());
+    }
+
+    @Test
+    @DisplayName("get by Wrapper")
+    void testGetByWrapper() {
+        // given
+        int chickenWeight = 1100;
+        Chicken chicken = new Chicken(chickenWeight, false);
+
+        // when
+        GetBy getBy = new GetBy();
+        getBy.makeBonelessByWrapper(chicken.getWeight(), chicken.isBoneless());
+
+        // then
+        System.out.println("chicken.getWeight() = " + chicken.getWeight());
+        System.out.println("chicken.isBoneless() = " + chicken.isBoneless());
+        Assertions.assertEquals(chickenWeight, chicken.getWeight());
+        Assertions.assertNotEquals(chickenWeight - GetBy.CHICKEN_BONE_WIGHT, chicken.getWeight());
+    }
+
+}


### PR DESCRIPTION
## Call by value와 Call by reference의 차이점을 확인하고자 한 코드작업입니다 ##

1. Get By Value (Call by value)
: 값으로서의 전달로, 복사된 데이터를 전달하여 이를 수정하여도 원본 데이터는 수정되지 않습니다. 메서드를 호출할 때 데이터를 넘겨주더라도 by value 방식이라면 메서드 안에서 값이 수정되더라도 원본 데이터는 영향을 받지 않습니다. 이유는 새로운 스택으로 복사된 **값**이 전달되기 때문

2. Get By Reference (Call by reference)
: 참조로서 전달로, 메서드의 매개변수가 지정된 변수의 레퍼런스로 초기화되는 것입니다. 따라서 메서드 안에서 해당 데이터를 수정하게 되면 공유된 데이터를 수정하므로 해당 데이터를 리턴하지 않아도 해당 레퍼런스를 가진 다른 스택 영역에서도 수정된 데이터를 확인할 수 있게 됩니다.

---

### 그렇다면 어떻게 사용해야 할까 ###
- 오브젝트(Object)라는 책에서, 변경자 메서드와 접근자 메서드를 구분지어야 한다는 내용을 본적이 있습니다. 값을 불러오는 메서드에서는 데이터의 수정이 있어서는 안되고, 값을 변경하는 메서드에서는 리턴값이 없어야 한다는 것이었습니다.
- 그 부분을 읽으면서, 값을 수정하고 그것을 받아오고 싶을때는 어떡하지? 라는 물음이 있었습니다. 지금은 Call by Reference를 통해 객체를 전달받고 이를 수정하여 void형태의 메서드가 가능하겠다는 생각이 듭니다. 물론 blocking 방식이어야 안전할 것입니다.

---

### 하나 더, 자바의 Wrapper 클래스를 사용하면 Call By Reference가 가능할가? ###
- 우선 Wrapper를 사용해서 얻을 수 있는 이점/기능은 다음과 같습니다.
  - Null 초기화 가능
  - 자료형간의 변환이 가능(메서드 제공)
  - Collection은 원시타입을 처리하지 않음
  - 제네릭 사용가능 (원시타입은 클래스가 아니므로)
  - 자동 boxing, unboxing으로 불편하지도 않다.
- 다시 돌아가서, Wrapper 클래스로 값을 전달하면 Call by Reference 일까요?
``` JAVA
    public void setUsingWrapper(Integer input){
        input++;
    }
```
- input이 과연 바뀔까요? 당연히 안바뀝니다. 이유는 다음과 같습니다.
  - Wrapper는 불변객체입니다.(String)도 마찬가지죠
  - <img width="640" alt="image" src="https://github.com/user-attachments/assets/cb6bf865-e123-44d5-9bef-97063c15d861">
<br>

- 따라서 Wrapper 객체의 값을 바꿀수는 없습니다.
- 그래도 객체니까 새로운 Integer 객체를 생성해서 변수값에 넣으면 되지않나?
  - 말을 하면서 틀린것을 알 수 있습니다. 변수값에 넣는다 -> 변수는 해당 스택에서만 존재하므로 원본에 영향을 주지 못하게 됩니다.
  - 이는 자바는 C와 다르게 call by value 방식이고, 주소값을 넘겨주지 못하기 때문입니다.
  - 주소값을 넘겨준게 아니라, 주소값을 가지고 있는 변수를 (복사해서) 넘겨준것이고, 변수에 새로운 주소값을 썼다고 해서 원본에 영향을 주지 못하는 것입니다. 단지 로컬변수가 수정되는 것 뿐입니다.
  - 따라서 아무리 객체를 매개변수로 전달받았다고 해도, 해당 변수를 다른 객체로 대입해도 소용이 없게됩니다.
  - <img width="568" alt="image" src="https://github.com/user-attachments/assets/301a85dc-427c-4ab6-a84c-e90e87accaed">

그래서 자바는 Call By Value인 것입니다.
따라서 자바에서 불변객체를 사용하게 되면 안전한 공유(Safe Sharing)가 가능해집니다.